### PR TITLE
concatenate compiled handlebars templates on change

### DIFF
--- a/config/application.coffee
+++ b/config/application.coffee
@@ -41,4 +41,4 @@ module.exports = require(process.env['LINEMAN_MAIN']).config.extend 'application
 
   watch:
     handlebars:
-      tasks: ["ember_handlebars:compile"]
+      tasks: ["ember_handlebars:compile", "concat:js"]


### PR DESCRIPTION
This just applies this fix made by @searls to the lineman-ember-template:
https://github.com/testdouble/lineman-ember-template/commit/c3e9b9e70858b52704f1e53477ecdf031340d2bb

To be honest, this was just a copy-and-paste job.  I reported an issue on that repo initially, but I really wanted to use this one.  I had the same problem with both repos, though, and the change here solved that problem.  (Originally reported here: https://github.com/testdouble/lineman-ember-template/issues/8.)
